### PR TITLE
Replace read by an infinite loop using sleep

### DIFF
--- a/warp10.start.sh
+++ b/warp10.start.sh
@@ -48,7 +48,7 @@ then
 
   # TODO ends this script if warp10 is not running properly
   echo "All process are running"
-  read
+  while true; do sleep 1; done
 else
   echo "Unable to launch Warp10, configuration missing"
   exit -1


### PR DESCRIPTION
Allow `docker run` to block even if `--detach` is not
appended to command line. Usefull for example when
using this image with gitlab ci.