### PR TITLE
Replace old regular expression to new one

### DIFF
--- a/predictible-tokens-for-ci/Dockerfile
+++ b/predictible-tokens-for-ci/Dockerfile
@@ -1,4 +1,4 @@
 FROM warp10io/warp10:1.2.6-rc1
 
 COPY ci.tokens ${WARP10_HOME}/etc/ci.tokens
-RUN sed s/"\#\ Launching\ Warp10"/"echo\ \"warp\.token\.file\ \=\ \${WARP10_HOME}\/etc\/ci\.tokens\"\ \>\>\ \${WARP10_VOLUME}\/warp10\/etc\/conf\-standalone\.conf"/ /opt/warp10/bin/warp10.start.sh -i
+RUN sed s/"echo \"Launch Warp10\""/"echo\ \"warp\.token\.file\ \=\ \${WARP10_HOME}\/etc\/ci\.tokens\"\ \>\>\ \${WARP10_VOLUME}\/warp10\/etc\/conf\-standalone\.conf"/ /opt/warp10/bin/warp10.start.sh -i


### PR DESCRIPTION
Since we wanted to append warp.token.file at the end of the configuration file
but before launching warp10, we were using a regular expression to point to this
very moment: '# Launching Warp10'.
This comment has been removed but a new instruction replaces it: 'echo "Launch Warp10"'.